### PR TITLE
fixed typo on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you also want to preserve search / register / unregister functionality (pleas
 ```json
 {
   "registry": {
-    "default": "https://raw.githubusercontent.com/bower/components/master",
+    "default": "https://raw.githubusercontent.com/bower/components/1.0.0",
     "search": "https://bower.herokuapp.com",
     "register": "https://bower.herokuapp.com",
     "publish": "https://bower.herokuapp.com"


### PR DESCRIPTION
Small correction to readme that I found while looking for something else. no big deal but we discourage using master just a couple paragraphs above.